### PR TITLE
remove futile.logger dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: aa9d728060685cc4093ebaec70ee29e633af64894385ada126840264fc9779a3
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
   rpaths:
@@ -27,7 +27,6 @@ requirements:
     - r-base >=3.3.0
     - r-curl
     - r-data.table
-    - r-futile.logger
     - r-jsonlite
     - r-purrr
     - r-stringr
@@ -36,7 +35,6 @@ requirements:
     - r-base >=3.3.0
     - r-curl
     - r-data.table
-    - r-futile.logger
     - r-jsonlite
     - r-purrr
     - r-stringr


### PR DESCRIPTION
v1.1.0 no longer depends on `{futile.logger}`: https://github.com/uptake/uptasticsearch/pull/260

This removes that dependency here.

## Notes for Reviewers
### Checklist

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.